### PR TITLE
Config fixes

### DIFF
--- a/Commands/ExploreCommand.cs
+++ b/Commands/ExploreCommand.cs
@@ -19,7 +19,7 @@ public class ExploreCommand
     {
         States.isInteracting = true; // The player will need to confirm / deny
         return new TerminalInteraction() // Starts terminal interaction (confirm / deny)
-            .WithPrompt($"You're going to route to a randomly chosen moon (If you see this, please open an issue on git hub, this is a bug : Value is {SyncConfig.Synced_var.Entry.Value}), for free.\n\nPlease CONFIRM or DENY")
+            .WithPrompt($"You're going to route to a randomly chosen moon (If you see this, please open an issue on git hub, this is a bug : Value is {RandomMoons.Config.SyncedVar}), for free.\n\nPlease CONFIRM or DENY")
             .WithHandler(onInteraction);
     }
 
@@ -39,7 +39,7 @@ public class ExploreCommand
         if (s.ToLower() == "c" || s.ToLower() == "confirm") // If the player confirms the interaction
         {
             // TODO: redo the way the config works below
-            if (States.hasGambled && SyncConfig.RestrictedCommandUsage.Value) // If the ship already explored
+            if (States.hasGambled && RandomMoons.Config.RestrictedCommandUsage.Value) // If the ship already explored
             {
                 return "You have already explored. Please land before exploring once again !";
             }
@@ -49,18 +49,12 @@ public class ExploreCommand
                 return "Please wait before travelling to a new moon !";
             }
 
-            SelectableLevel moon = ChooseRandomMoon(terminal.moonsCatalogueList); // Choose a random moon amongst the moons shown in terminal
-
-            // TODO: redo the way the config works below 
-
-            //if (SyncConfig.Synced && SyncConfig.IsClient) {
-            //  RandomMoons.Logger.LogInfo("Config synced with host");
-            //}
-
-            StartOfRound.Instance.ChangeLevelServerRpc(moon.levelID, terminal.groupCredits); // Travel to the chosen moon, at no cost
+            // Choose a random moon from moons shown in the terminal and travel to it at no cost.
+            SelectableLevel moon = ChooseRandomMoon(terminal.moonsCatalogueList); 
+            StartOfRound.Instance.ChangeLevelServerRpc(moon.levelID, terminal.groupCredits);
 
             // If AutoStart enabled, tell StartOfRoundPatch to start a level asap
-            if (SyncConfig.AutoStart.Value)
+            if (RandomMoons.Config.AutoStart.Value)
                 States.startUponArriving = true;
 
             States.lastVisitedMoon = moon.PlanetName;
@@ -92,7 +86,7 @@ public class ExploreCommand
 
         // TODO: redo the way the config works
 
-        var type = SyncConfig.MoonSelectionType.Value;
+        MoonSelection type = RandomMoons.Config.MoonSelectionType.Value;
 
         // Checks moon selection config entry
         if (type == MoonSelection.VANILLA && !IsMoonVanilla(moons[moonIndex]) || type == MoonSelection.MODDED && IsMoonVanilla(moons[moonIndex]))
@@ -101,11 +95,11 @@ public class ExploreCommand
         }
 
         // Checks the register travels config entry
-        if (SyncConfig.CheckIfVisitedDuringQuota.Value && States.visitedMoons.Contains(moons[moonIndex].PlanetName))
+        if (RandomMoons.Config.CheckIfVisitedDuringQuota.Value && States.visitedMoons.Contains(moons[moonIndex].PlanetName))
         {
             return ChooseRandomMoon(moons);
         }
-            
+
         // Reset visitedMoons list if all the moons have been visited
         if (States.visitedMoons.Count == moons.Length)
         {

--- a/Commands/ExploreCommand.cs
+++ b/Commands/ExploreCommand.cs
@@ -19,7 +19,7 @@ public class ExploreCommand
     {
         States.isInteracting = true; // The player will need to confirm / deny
         return new TerminalInteraction() // Starts terminal interaction (confirm / deny)
-            .WithPrompt($"You're going to route to a randomly chosen moon (If you see this, please open an issue on git hub, this is a bug : Value is {RandomMoons.Config.SyncedVar}), for free.\n\nPlease CONFIRM or DENY")
+            .WithPrompt($"You're going to route to a randomly chosen moon (If you see this, please open an issue on GitHub, this is a bug : Value is {RandomMoons.Config.SyncedVar}), for free.\n\nPlease CONFIRM or DENY")
             .WithHandler(onInteraction);
     }
 

--- a/Commands/ExploreCommand.cs
+++ b/Commands/ExploreCommand.cs
@@ -19,7 +19,7 @@ public class ExploreCommand
     {
         States.isInteracting = true; // The player will need to confirm / deny
         return new TerminalInteraction() // Starts terminal interaction (confirm / deny)
-            .WithPrompt($"You're going to route to a randomly chosen moon (If you see this, please open an issue on GitHub, this is a bug : Value is {RandomMoons.Config.SyncedVar}), for free.\n\nPlease CONFIRM or DENY")
+            .WithPrompt($"You're going to route to a randomly chosen moon (If you see this, please open an issue on GitHub, this is a bug : Value is {RMConfig.Instance.SyncedVar}), for free.\n\nPlease CONFIRM or DENY")
             .WithHandler(onInteraction);
     }
 

--- a/ConfigUtils/Config.cs
+++ b/ConfigUtils/Config.cs
@@ -8,84 +8,81 @@ using LethalConfig.ConfigItems.Options;
 using LethalSettings.UI;
 using LethalSettings.UI.Components;
 
-namespace RandomMoons.ConfigUtils {
-    [DataContract]
-    public class SyncConfig : SyncedConfig<SyncConfig>
+namespace RandomMoons.ConfigUtils;
+
+[DataContract]
+public class RMConfig : SyncedConfig<RMConfig>
+{
+    // Should we start the level when traveling to a new moon ? 
+    public ConfigEntry<bool> AutoStart { get; private set; }
+
+    // Should we explore a new moon once the level has ended ? 
+    public ConfigEntry<bool> AutoExplore { get; private set; }
+
+    // Should we be able to visit the same moon twice during a quota ?
+    public ConfigEntry<bool> CheckIfVisitedDuringQuota { get; private set; }
+
+    // Should the player be able to explore multiples times ?
+    public ConfigEntry<bool> RestrictedCommandUsage { get; private set; }
+
+    // What kind of moons can be selected ?
+    public ConfigEntry<MoonSelection> MoonSelectionType { get; private set; }
+
+    // Variable to try and sync
+    [DataMember] public SyncedEntry<int> SyncedVar { get; private set; }
+
+    // Bind config entries
+    public RMConfig(ConfigFile cfg) : base("InnohVateur.RandomMoons")
     {
-        // Should we start the level when traveling to a new moon ? 
-        public static ConfigEntry<bool> AutoStart; 
+        ConfigManager.Register(this);
 
-        // Should we explore a new moon once the level has ended ? 
-        public static ConfigEntry<bool> AutoExplore;
+        AutoStart = cfg.Bind(
+            "General",
+            "AutoStart",
+            false,
+            "Automatically starts the level upon travelling to a random moon"
+        );
 
-        // Should we be able to visit the same moon twice during a quota ?
-        public static ConfigEntry<bool> CheckIfVisitedDuringQuota;
+        AutoExplore = cfg.Bind(
+            "General",
+            "AutoExplore",
+            false,
+            "Automatically explore to a random moon upon leaving the level"
+        );
 
-        // Should the player be able to explore multiples times ?
-        public static ConfigEntry<bool> RestrictedCommandUsage;
+        CheckIfVisitedDuringQuota = cfg.Bind(
+            "General",
+            "RegisterTravels",
+            false,
+            "The same moon can't be chosen twice while the quota hasn't changed"
+        );
 
-        // What kind of moons can be selected ?
-        public static ConfigEntry<MoonSelection> MoonSelectionType;
+        RestrictedCommandUsage = cfg.Bind(
+            "General",
+            "PreventMultipleTravels",
+            true,
+            "Prevents the players to execute explore multiple times without landing"
+        );
 
-        // Variable to try and sync
-        [DataMember] public static SyncedEntry<int> Synced_var { get; private set; }
-
-        // Bind config entries
-        public SyncConfig(ConfigFile cfg) : base("InnohVateur.RandomMoons")
-        {
-            ConfigManager.Register(this);
-
-            AutoStart = cfg.Bind(
-                "General",
-                "AutoStart",
-                false,
-                "Automatically starts the level upon travelling to a random moon"
-            );
-
-            AutoExplore = cfg.Bind(
-                "General",
-                "AutoExplore",
-                false,
-                "Automatically explore to a random moon upon leaving the level"
-            );
-
-            CheckIfVisitedDuringQuota = cfg.Bind(
-                "General",
-                "RegisterTravels",
-                false,
-                "The same moon can't be chosen twice while the quota hasn't changed"
-            );
-
-            RestrictedCommandUsage = cfg.Bind(
-                "General",
-                "PreventMultipleTravels",
-                true,
-                "Prevents the players to execute explore multiple times without landing"
-            );
-
-            MoonSelectionType = cfg.Bind(
-                "General",
-                "MoonSelection",
-                MoonSelection.ALL,
-                "Can have three values : vanilla, modded or all, to change the moons that can be chosen. (Note : modded input without modded moons would do the same as all)"
-            );
+        MoonSelectionType = cfg.Bind(
+            "General",
+            "MoonSelection",
+            MoonSelection.ALL,
+            "Can have three values : vanilla, modded or all, to change the moons that can be chosen. (Note : modded input without modded moons would do the same as all)"
+        );
             
-            // Synced variable try
-            Synced_var = cfg.BindSyncedEntry(
-                new ConfigDefinition("Please work", "Please work2"),
-                4,
-                new ConfigDescription("Please be synced for the love of god")
-            );
+        SyncedVar = cfg.BindSyncedEntry(
+            new ConfigDefinition("Please work", "Please work2"),
+            4,
+            new ConfigDescription("Please be synced for the love of god")
+        );
 
-            var configEntry = cfg.Bind("General", "Example", 0, "This is an example component!");
+        var SyncedVarInput = new IntSliderConfigItem(SyncedVar.Entry, new IntSliderOptions{
+            RequiresRestart = false,
+            Min = 0,
+            Max = 100
+        });
 
-            var Synced_var_input = new IntSliderConfigItem(Synced_var.Entry, new IntSliderOptions{
-                RequiresRestart = false,
-                Min = 0,
-                Max = 100
-            });
-
-            LethalConfigManager.AddConfigItem(Synced_var_input);
-        }
+        LethalConfigManager.AddConfigItem(SyncedVarInput);
     }
 }

--- a/ConfigUtils/Config.cs
+++ b/ConfigUtils/Config.cs
@@ -5,8 +5,6 @@ using CSync.Util;
 using LethalConfig;
 using LethalConfig.ConfigItems;
 using LethalConfig.ConfigItems.Options;
-using LethalSettings.UI;
-using LethalSettings.UI.Components;
 
 namespace RandomMoons.ConfigUtils;
 

--- a/Patches/GameNetworkManagerPatch.cs
+++ b/Patches/GameNetworkManagerPatch.cs
@@ -1,20 +1,19 @@
 ﻿using HarmonyLib;
 using RandomMoons.Utils;
 
-namespace RandomMoons.Patches
+namespace RandomMoons.Patches;
+
+/// <summary>
+/// Patches GameNetworkManager. Learn to read
+/// </summary>
+[HarmonyPatch(typeof(GameNetworkManager))]
+internal class GameNetworkManagerPatch
 {
-    /// <summary>
-    /// Patches GameNetworkManager. Learn to read
-    /// </summary>
-    [HarmonyPatch(typeof(GameNetworkManager))]
-    internal class GameNetworkManagerPatch
+    // When player disconnects, makes hasGambled false
+    [HarmonyPatch("StartDisconnect")]
+    [HarmonyPrefix]
+    public static void StartDisconnectPatch()
     {
-        // When player disconnects, makes hasGambled false
-        [HarmonyPatch("StartDisconnect")]
-        [HarmonyPrefix]
-        public static void StartDisconnectPatch()
-        {
-            States.hasGambled = false;
-        }
+        States.hasGambled = false;
     }
 }

--- a/Patches/StartOfRoundPatch.cs
+++ b/Patches/StartOfRoundPatch.cs
@@ -55,7 +55,7 @@ internal class StartOfRoundPatch
             // If there are more than 0 days left, perform the same as explore command, else travel to Gordion (Company Building)
             if (TimeOfDay.Instance.daysUntilDeadline > 0 || __instance.currentLevelID == States.companyBuildingLevelID)
             {
-                SelectableLevel moon = ExploreCommand.chooseRandomMoon(terminal.moonsCatalogueList);
+                SelectableLevel moon = ExploreCommand.ChooseRandomMoon(terminal.moonsCatalogueList);
                 __instance.ChangeLevelServerRpc(moon.levelID, terminal.groupCredits);
                 States.lastVisitedMoon = moon.PlanetName;
                 States.hasGambled = true;

--- a/Patches/StartOfRoundPatch.cs
+++ b/Patches/StartOfRoundPatch.cs
@@ -49,7 +49,7 @@ internal class StartOfRoundPatch
         if (__instance.CanChangeLevels() && States.exploreASAP) // Performs auto explore
         {
             // TODO: redo the way the configs works
-            if (SyncConfig.AutoStart.Value)
+            if (RandomMoons.Config.AutoStart.Value)
                 States.startUponArriving = true;
 
             // If there are more than 0 days left, perform the same as explore command, else travel to Gordion (Company Building)

--- a/Patches/StartOfRoundPatch.cs
+++ b/Patches/StartOfRoundPatch.cs
@@ -41,10 +41,10 @@ internal class StartOfRoundPatch
         }
 
         // Performs auto start
-        if (!__instance.travellingToNewLevel && States.confirmedAutostart)
-        {
+        //if (!__instance.travellingToNewLevel && States.confirmedAutostart)
+        //{
                 
-        }
+        //}
 
         if (__instance.CanChangeLevels() && States.exploreASAP) // Performs auto explore
         {

--- a/Patches/TerminalPatch.cs
+++ b/Patches/TerminalPatch.cs
@@ -15,12 +15,10 @@ public class TerminalPatch
     // Checks if a player leaved upon confirming explore command
     [HarmonyPatch("QuitTerminal")]
     [HarmonyPrefix]
-    public static void QuitTerminalPatch(Terminal __instance)
+    public static void QuitTerminalPatch()
     {
-        if(States.isInteracting)
-        {
+        if (States.isInteracting)
             States.closedUponConfirmation = true;
-        }
     }
 
     // Checks if the moon selection config entry can be set to MODDED
@@ -28,13 +26,14 @@ public class TerminalPatch
     [HarmonyPrefix]
     public static void BeginUsingTerminalPatch(Terminal __instance)
     {
-        if(SyncConfig.MoonSelectionType.Value == MoonSelection.MODDED)
-        {
-            foreach(SelectableLevel lvl in __instance.moonsCatalogueList) {
-                if(!States.vanillaMoons.Contains(lvl.sceneName)) { return; }
-            }
+        if (RandomMoons.Config.MoonSelectionType.Value != MoonSelection.MODDED)
+            return;
 
-            SyncConfig.MoonSelectionType.Value = MoonSelection.ALL;
+        foreach (SelectableLevel lvl in __instance.moonsCatalogueList) {
+            if (!States.vanillaMoons.Contains(lvl.sceneName)) 
+                return;
         }
+
+        RandomMoons.Config.MoonSelectionType.Value = MoonSelection.ALL;
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -29,9 +29,6 @@ public class RandomMoons : BaseUnityPlugin
     // Harmony instance
     readonly Harmony harmony = new(modGUID);
 
-    // Plugin instance
-    static RandomMoons Instance;
-
     // Terminal API Registry Instance
     TerminalModRegistry Commands;
 
@@ -39,19 +36,15 @@ public class RandomMoons : BaseUnityPlugin
     public static new RMConfig Config { get; private set; }
 
     // Executed at start
-    private void Awake()
+    void Awake()
     {
-        // Instantiates the Plugin
-        if (Instance == null)
-            Instance = this;
-
         Logger = base.Logger;
+
         Config = new(base.Config);
+        Config.SyncComplete += CheckSynced;
 
-        // Instantiates the Terminal API Registry
+        // Create Terminal and register our commands.
         Commands = TerminalRegistry.CreateTerminalRegistry();
-
-        // Registers the commands
         Commands.RegisterFrom(new ExploreCommand());
 
         try {
@@ -68,7 +61,7 @@ public class RandomMoons : BaseUnityPlugin
     }
 
     // Apply harmony patches
-    private void ApplyPluginPatches()
+    void ApplyPluginPatches()
     {
         harmony.PatchAll(typeof(RandomMoons));
         Logger.LogInfo("Patched RandomMoons");
@@ -78,5 +71,14 @@ public class RandomMoons : BaseUnityPlugin
 
         harmony.PatchAll(typeof(StartOfRoundPatch));
         Logger.LogInfo("Patched StartOfRound");
+    }
+
+    void CheckSynced(bool success) {
+        if (!success) {
+            Logger.LogDebug("SYNC FAILED");
+            return;
+        }
+
+        Logger.LogDebug($"Commands registered! SyncedVar: {RMConfig.Instance.SyncedVar}");
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -36,7 +36,7 @@ public class RandomMoons : BaseUnityPlugin
     private TerminalModRegistry Commands;
 
     internal new static ManualLogSource Logger;
-    public static new SyncConfig Config;
+    public static new RMConfig Config;
 
     // Executed at start
     private void Awake()

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -27,16 +27,16 @@ public class RandomMoons : BaseUnityPlugin
     internal const string modVersion = "1.3.0";
 
     // Harmony instance
-    private readonly Harmony harmony = new(modGUID);
+    readonly Harmony harmony = new(modGUID);
 
     // Plugin instance
-    private static RandomMoons Instance;
+    static RandomMoons Instance;
 
     // Terminal API Registry Instance
-    private TerminalModRegistry Commands;
+    TerminalModRegistry Commands;
 
-    internal new static ManualLogSource Logger;
-    public static new RMConfig Config;
+    internal static new ManualLogSource Logger;
+    public static new RMConfig Config { get; private set; }
 
     // Executed at start
     private void Awake()
@@ -64,7 +64,7 @@ public class RandomMoons : BaseUnityPlugin
         }
 
         // Plugin loaded!
-        Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded and operational ! Have fun");
+        Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded and operational. Have fun!");
     }
 
     // Apply harmony patches

--- a/RandomMoons.csproj
+++ b/RandomMoons.csproj
@@ -18,9 +18,7 @@
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-    <PackageReference Include="Owen3H.BepInEx.CSync" Version="3.0.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
@@ -28,32 +26,26 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
       <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
+    <Reference Include="CSync">
+      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\CSync.dll</HintPath>
+    </Reference>
     <Reference Include="LethalAPI.Terminal">
-      <HintPath>..\..\..\..\DEPENDENCIES\LethalAPI.Terminal.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalAPI.Terminal.dll</HintPath>
     </Reference>
     <Reference Include="LethalConfig">
-      <HintPath>..\..\..\..\DEPENDENCIES\LethalConfig.dll</HintPath>
-    </Reference>
-    <Reference Include="LethalSettings">
-      <HintPath>..\..\..\..\DEPENDENCIES\LethalSettings.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalConfig\LethalConfig.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Collections">
-      <HintPath>..\..\..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Collections.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>..\..\..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
@@ -61,8 +53,9 @@
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="echo &quot;.&quot; &gt; &quot;E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\$(TargetName).dll&quot; &amp;&amp; xcopy /q /y /i &quot;$(TargetPath)&quot; &quot;E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\$(TargetName).dll&quot;" />
+  </Target>
 </Project>

--- a/RandomMoons.csproj
+++ b/RandomMoons.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <PackageReference Include="Owen3H.BepInEx.CSync" Version="3.*" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
   </ItemGroup>
   
@@ -27,25 +28,22 @@
   
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
       <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
-    <Reference Include="CSync">
-      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\CSync.dll</HintPath>
-    </Reference>
     <Reference Include="LethalAPI.Terminal">
-      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalAPI.Terminal.dll</HintPath>
+      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalAPI.Terminal.dll</HintPath>
     </Reference>
     <Reference Include="LethalConfig">
-      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalConfig\LethalConfig.dll</HintPath>
+      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalConfig.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Collections">
-      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Collections.dll</HintPath>
+      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>E:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
+      <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
@@ -54,8 +52,4 @@
       <HintPath>..\..\..\..\..\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="echo &quot;.&quot; &gt; &quot;E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\$(TargetName).dll&quot; &amp;&amp; xcopy /q /y /i &quot;$(TargetPath)&quot; &quot;E:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\$(TargetName).dll&quot;" />
-  </Target>
 </Project>

--- a/Utils/States.cs
+++ b/Utils/States.cs
@@ -1,21 +1,25 @@
 ﻿using System.Collections.Generic;
 
-namespace RandomMoons.Utils
+namespace RandomMoons.Utils;
+
+/// <summary>
+/// All the important state variables / constant variables
+/// </summary>
+internal class States
 {
-    /// <summary>
-    /// All the important state variables / constant variables
-    /// </summary>
-    internal class States
-    {
-        public static bool closedUponConfirmation = false; // If the terminal closed while confirming explore command
-        public static bool isInteracting = false; // If the player is currently confirming or denying explore command
-        public static bool hasGambled = false; // If someone used explore / if the ship autoExplored the current day
-        public static bool startUponArriving = false; // If the level needs to start upon finishing travelling
-        public static bool confirmedAutostart = false; // Confirms startUponArriving (actually needed)
-        public static bool exploreASAP = false; // If the ship should travel to a random moon upon finishing leaving the current level
-        public static List<string> visitedMoons = new List<string>(); // Lists the moons visited by exploring during the current quota
-        public static readonly string[] vanillaMoons = { "Level1Experimentation", "Level2Assurance", "Level3Vow", "Level4March", "Level5Rend", "Level6Dine", "Level7Offense", "Level8Titan" }; // TODO: Add new moons added with V50.  All vanilla moons scene names 
-        public static readonly int companyBuildingLevelID = 3; // Gordion (Company Building) level ID
-        public static string lastVisitedMoon; // Last visited moon using explore command / ship autoExplore
-    }
+    public static bool closedUponConfirmation = false; // If the terminal closed while confirming explore command
+    public static bool isInteracting = false; // If the player is currently confirming or denying explore command
+    public static bool hasGambled = false; // If someone used explore / if the ship autoExplored the current day
+    public static bool startUponArriving = false; // If the level needs to start upon finishing travelling
+    public static bool confirmedAutostart = false; // Confirms startUponArriving (actually needed)
+    public static bool exploreASAP = false; // If the ship should travel to a random moon upon finishing leaving the current level
+    public static List<string> visitedMoons = []; // Lists the moons visited by exploring during the current quota
+
+    // TODO: Add new moons added with V50. All vanilla moons scene names 
+    public static readonly string[] vanillaMoons = { 
+        "Level1Experimentation", "Level2Assurance", "Level3Vow", "Level4March", "Level5Rend", "Level6Dine", "Level7Offense", "Level8Titan" 
+    };
+
+    public static readonly int companyBuildingLevelID = 3; // Gordion (Company Building) level ID
+    public static string lastVisitedMoon; // Last visited moon using explore command / ship autoExplore
 }


### PR DESCRIPTION
- A little bit more project QoL.
- Renamed `SyncConfig` to `RMConfig` (RandomMoons) as it also contains unsynced entries.
- Added private setters to the regular `ConfigEntry`s.
- Removed the `static` keyword from all config entries as they should be referenced via an instance.
- Replaced all references to synced variables that caused them to always have their default value.
   - `SyncConfig.SyncedVar` -> `RMConfig.Instance.SyncedVar`