### PR TITLE
RandomMoons fixes and port to csync 5.0.1

### DIFF
--- a/Commands/DisplayConfigCommand.cs
+++ b/Commands/DisplayConfigCommand.cs
@@ -1,4 +1,6 @@
-﻿using BepInEx.Logging;
+using BepInEx.Logging;
+using CSync;
+using CSync.Lib;
 using LethalAPI.LibTerminal.Attributes;
 using LethalAPI.LibTerminal.Interactions;
 using LethalAPI.LibTerminal.Interfaces;
@@ -27,12 +29,12 @@ namespace RandomMoons.Commands
             ///</summary>
 
             string ConfigString;
-
+         
 
             //We want to create a string that contain all of the current config, and the state of the syncing.
 
-            ConfigString = $"{RMConfig.Instance.AutoStart}, {RMConfig.Instance.AutoExplore}, {RMConfig.Instance.CheckIfVisitedDuringQuota}, "
-                + $"{RMConfig.Instance.RestrictedCommandUsage}, {RMConfig.Instance.MoonSelectionType}";
+            ConfigString = $"{RandomMoons.Config.AutoStart}, {RandomMoons.Config.AutoExplore}, {RandomMoons.Config.CheckIfVisitedDuringQuota}, "
+                + $"{RandomMoons.Config.RestrictedCommandUsage}, {RandomMoons.Config.MoonSelectionType}";
 
 
 

--- a/Commands/ExploreCommand.cs
+++ b/Commands/ExploreCommand.cs
@@ -44,7 +44,7 @@ public class ExploreCommand
         if (s.ToLower() == "c" || s.ToLower() == "confirm") // If the player confirms the interaction
         {
             // TODO: redo the way the config works below
-            if (States.hasGambled && RMConfig.Instance.RestrictedCommandUsage.Value) // If the ship already explored
+            if (States.hasGambled && RandomMoons.Config.RestrictedCommandUsage.Value) // If the ship already explored
             {
                 return "You have already explored. Please land before exploring once again !";
             }
@@ -59,8 +59,11 @@ public class ExploreCommand
             StartOfRound.Instance.ChangeLevelServerRpc(moon.levelID, terminal.groupCredits);
 
             // If AutoStart enabled, tell StartOfRoundPatch to start a level asap
-            if (RMConfig.Instance.AutoStart.Value)
+            if (RandomMoons.Config.AutoStart.Value)
+            {
                 States.startUponArriving = true;
+                
+            }
 
             States.lastVisitedMoon = moon.PlanetName;
             States.isInteracting = false; // End of interaction
@@ -91,7 +94,7 @@ public class ExploreCommand
 
         // TODO: redo the way the config works
 
-        MoonSelection type = RMConfig.Instance.MoonSelectionType.Value;
+        MoonSelection type = RandomMoons.Config.MoonSelectionType.Value;
 
         // Checks moon selection config entry
         // if the config wants vanilla and random is not then recursiv           if the config wants modded and random is vanilla then recursiv
@@ -101,7 +104,7 @@ public class ExploreCommand
         }
 
         // Checks the register travels config entry
-        if (RMConfig.Instance.CheckIfVisitedDuringQuota.Value && States.visitedMoons.Contains(moons[moonIndex].PlanetName))
+        if (RandomMoons.Config.CheckIfVisitedDuringQuota.Value && States.visitedMoons.Contains(moons[moonIndex].PlanetName))
         {
             return ChooseRandomMoon(moons);
         }

--- a/ConfigUtils/MoonSelection.cs
+++ b/ConfigUtils/MoonSelection.cs
@@ -5,7 +5,7 @@ namespace RandomMoons.ConfigUtils;
 /// <summary>
 /// Possible values for the MoonSelection config entry
 /// </summary>
-[DataContract]
+
 public enum MoonSelection
 {
     [EnumMember] ALL,       //All the moons

--- a/Patches/TerminalPatch.cs
+++ b/Patches/TerminalPatch.cs
@@ -26,7 +26,7 @@ public class TerminalPatch
     [HarmonyPrefix]
     public static void BeginUsingTerminalPatch(Terminal __instance)
     {
-        if (RMConfig.Instance.MoonSelectionType.Value != MoonSelection.MODDED)
+        if (RandomMoons.Config.MoonSelectionType.Value != MoonSelection.MODDED)
             return;
 
         foreach (SelectableLevel lvl in __instance.moonsCatalogueList) {
@@ -34,6 +34,6 @@ public class TerminalPatch
                 return;
         }
 
-        RMConfig.Instance.MoonSelectionType.Value = MoonSelection.ALL;
+        RandomMoons.Config.MoonSelectionType.LocalValue = MoonSelection.ALL;
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -2,10 +2,10 @@
 using BepInEx;
 using BepInEx.Logging;
 using CSync;
+using CSync.Lib;
 using HarmonyLib;
 using LethalAPI.LibTerminal;
 using LethalAPI.LibTerminal.Models;
-using LethalConfig;
 using RandomMoons.Commands;
 using RandomMoons.ConfigUtils;
 using RandomMoons.Patches;
@@ -19,14 +19,13 @@ namespace RandomMoons;
 [BepInPlugin(modGUID, modName, modVersion)]
 [BepInDependency("LethalAPI.Terminal")] // TODO: update version Thunderstore mod id : LethalAPI-LethalAPI_Terminal-1.0.1
 [BepInDependency("ainavt.lc.lethalconfig", BepInDependency.DependencyFlags.SoftDependency)] // TODO: update version Thunderstore mod id : AinaVT-LethalConfig-1.3.4
-[BepInDependency("com.willis.lc.lethalsettings", BepInDependency.DependencyFlags.SoftDependency)] // TODO: update version Thunderstore mod id : willis81808-LethalSettings-1.4.0
-[BepInDependency("io.github.CSync")]
+[BepInDependency("com.sigurd.csync", "5.0.1")]
 public class RandomMoons : BaseUnityPlugin
 {
     // Basic mod infos
     internal const string modGUID = "InnohVateur.RandomMoons";
     internal const string modName = "RandomMoons";
-    internal const string modVersion = "1.3.0";
+    internal const string modVersion = "1.4.0";
 
     // Harmony instance
     readonly Harmony harmony = new(modGUID);
@@ -34,21 +33,27 @@ public class RandomMoons : BaseUnityPlugin
     // Terminal API Registry Instance
     TerminalModRegistry Commands;
 
-    internal static new ManualLogSource Logger;
-    public static new RMConfig Config { get; private set; }
+    internal static new ManualLogSource Logger = null!;
+    internal static new RMConfig Config { get; private set; } = null!;
 
     // Executed at start
     void Awake()
     {
         Logger = base.Logger;
 
-        Config = new(base.Config);
-        Config.SyncComplete += CheckSynced;
+        Config = new RMConfig(base.Config);
 
-        // Create Terminal and register our commands.
-        Commands = TerminalRegistry.CreateTerminalRegistry();
+        //Attempt to fix the check synced
+        //Config.InitialSyncCompleted += CheckSynced; //doesnt work       
+        //RMConfig RandomMoons.Config.InitialSyncCompleted += (sender, args) => ;
+            //Config.InitialSyncComplete += CheckSynced;
+
+
+            // Create Terminal and register our commands.
+            Commands = TerminalRegistry.CreateTerminalRegistry();
         Commands.RegisterFrom(new ExploreCommand());
-        //Commands.RegisterFrom(new DisplayConfigCommand());
+        Commands.RegisterFrom(new DisplayConfigCommand());
+
 
         try {
             Logger.LogInfo("Applying patches...");
@@ -76,7 +81,10 @@ public class RandomMoons : BaseUnityPlugin
         Logger.LogInfo("Patched StartOfRound");
     }
 
-    void CheckSynced(bool success) {
+    //void CheckSynced(object sender, EventArgs success)
+    void CheckSynced(bool sender, bool success) {
+        
+    /*
         if (!success) {
             Logger.LogWarning("SYNC FAILED");
             States.ConfigStatus = false;
@@ -89,7 +97,9 @@ public class RandomMoons : BaseUnityPlugin
             States.ConfigStatus = true;
             return;
         }
-
-        Logger.LogDebug($"Commands registered! SyncedVar: {RMConfig.Instance.SyncedVar}");
+     */   
+        Logger.LogDebug($"Commands registered! SyncedVar: {RandomMoons.Config.SyncedVar}");
+        Logger.LogDebug("success value: " + success);
     }
+    
 }

--- a/RandomMoons.csproj
+++ b/RandomMoons.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -15,10 +15,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Lethal Company\**" />
+    <EmbeddedResource Remove="Lethal Company\**" />
+    <None Remove="Lethal Company\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-    <PackageReference Include="Owen3H.BepInEx.CSync" Version="3.*" />
+    <PackageReference Include="Sigurd.BepInEx.CSync" Version="5.0.1" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
   </ItemGroup>
   

--- a/Utils/States.cs
+++ b/Utils/States.cs
@@ -18,9 +18,8 @@ internal class States
     //Config stuff
     public static bool ConfigStatus;
 
-    // TODO: Add new moons added with V50. All vanilla moons scene names 
     public static readonly string[] vanillaMoons = { 
-        "Level1Experimentation", "Level2Assurance", "Level3Vow", "Level4March", "Level5Rend", "Level6Dine", "Level7Offense", "Level8Titan" 
+        "Level1Experimentation", "Level2Assurance", "Level3Vow", "Level4March", "Level5Rend", "Level6Dine", "Level7Offense", "Level8Titan", "Level9Artifice", "Level10Adamance", "Level11Embrion"  
     };
 
     public static readonly int companyBuildingLevelID = 3; // Gordion (Company Building) level ID


### PR DESCRIPTION
Ok I think I fixed mostly every major problem
Remember to add for thunderstore [FixPluginTypesSerialization](https://thunderstore.io/c/lethal-company/p/Evaisa/FixPluginTypesSerialization/)
 if you want the mod here is the file to test
 [RandomMoons.zip](https://github.com/user-attachments/files/16401214/RandomMoons.zip)
 and here is the changelog

- Ported to Sigurd-CSync-5.0.1(stupid serialization)
- Removed some unused stuff
- Made lethalconfig an actual soft dependency Fixed #12  
- Removed compatibility with LethalSettings(its old+it wasnt working anyway)
- Added some null check(just in case)
- Added more logs
- Added V50 moons to States.cs(add more moons in like a week lol)
- Fixed autoExplore config not working properly Fixed #2, #12  
- Fixed autoStart config not working properly Fixed #2,  #12   
- Changed Config to internal
- Added FixPluginTypesSerialization(definitely didnt spent three hours trying to solve a serialization problem with csync)
